### PR TITLE
Reset box-sizing so that we can enforce ribbon height.

### DIFF
--- a/src/scss/_affiliate-ribbon.scss
+++ b/src/scss/_affiliate-ribbon.scss
@@ -5,6 +5,7 @@
 		padding: 15px 0;
 		height: 18px;
 		text-align: right;
+		box-sizing: content-box;
 
 		&__container {
 			@include oGridContainer($grid-mode: 'fluid');


### PR DESCRIPTION
I totally forgot about this before, but as we depend on `content-box` to ensure that the ribbon is 18px in height, consuming products can use using resets/etc... which may adjust this on a global scale.