### PR TITLE
No longer output ie6-8 png fallback.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -23,9 +23,5 @@
 	} @else {
 		$url: "https://www.ft.com/__origami/service/build/v2/files/o-ft-affiliate-ribbon/src/img/service-from-ft.svg";
 	}
-
-	// sass-lint:disable no-duplicate-properties
 	background-image: url($url + "?source=o-ft-affiliate-ribbon&format=svg");
-	background-image: url($url + "?source=o-ft-affiliate-ribbon&&format=png&width=#{$fallback-width}") \9; // Browser hack to get a png fallback for browsers that don't support SVG
-	// sass-lint:enable no-duplicate-properties
 }


### PR DESCRIPTION
No longer output ie6-8 png fallback.
We do not actively support these browsers, this will reduce our CSS size.